### PR TITLE
fix: removes dependency on `react` and `react-dom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,6 @@
     "ellipsis",
     "multiline"
   ],
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
   "peerDependencies": {
     "react": ">=19.0.0 || >=18.0.0 || >=17.0.0 || >=16.0.0",
     "react-dom": ">=19.0.0 || >=18.0.0 || >=17.0.0 || >=16.0.0"
@@ -81,6 +77,8 @@
     "nyc": "^15.1.0",
     "prettier": "^3.2.5",
     "raf": "^3.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "sinon": "^17.0.1",
     "tsup": "^8.0.2",


### PR DESCRIPTION
Moves these to `devDependencies` so when this library is installed it uses the project's version of `react` instead of its own.

These are causing multiple version of react errors in projects which do not use `react@18.2.0`