### PR TITLE
chore: include letter-spacing for more accurate measurements on Truncate

### DIFF
--- a/src/Truncate/Truncate.tsx
+++ b/src/Truncate/Truncate.tsx
@@ -64,7 +64,10 @@ export const Truncate: React.FC<TruncateProps> = ({
       style.fontFamily,
     ].join(' ')
 
-    if (canvasContext) canvasContext.font = font
+    if (canvasContext) {
+      canvasContext.font = font
+      canvasContext.letterSpacing = style.letterSpacing
+    }
 
     setTargetWidth(newTargetWidth)
   }, [canvasContext, width])


### PR DESCRIPTION
This is how component using `<ShowMore />` component looks like at the moment with `letter-spacing` set to `o.5px`.

<img width="300" alt="Screenshot 2024-10-22 at 10 44 15 AM" src="https://github.com/user-attachments/assets/a1e35ed4-5cb0-4c63-bffe-c39dc324708a">

And this is how it looks like with this minor change

<img width="300" alt="Screenshot 2024-10-22 at 10 44 23 AM" src="https://github.com/user-attachments/assets/ffb575ae-da54-4ef5-94aa-2e36b5e985ec">



I saw the revert commit where you had previously tried applying `letter-spacing` along with other font properties (e.g. `font-weight`, `font-style`). I don't know that's the reason behind removing it but from my understanding `letter-spacing` exists only on canvas context itself, passing it along with other font properties should not work.


I did not run `gen:changelog` or `gen:release` since I'm unfamiliar with the flow honestly. Also tests weren't working for me because of `babel-polyfill` and `babel-core/register` packages.

If you could test this on your side an let me know if everything works as expected and you have no regressions. If that's the case you can assist me on how to create new release of the package.

Thanks a lot