### PR TITLE
Fix: Invoke `onTruncate` callback in `ShowMore` component

### DIFF
--- a/src/ShowMore/ShowMore.tsx
+++ b/src/ShowMore/ShowMore.tsx
@@ -22,6 +22,7 @@ export const ShowMore = forwardRef<ShowMoreRef, ShowMoreProps>(
       less = 'Collapse',
       anchorClass,
       onToggle,
+      onTruncate,
       children,
       ...rests
     },
@@ -77,7 +78,13 @@ export const ShowMore = forwardRef<ShowMoreRef, ShowMoreProps>(
               toggleLines={toggleLines}
             />
           }
-          onTruncate={handleTruncate}
+          onTruncate={(disTruncate) => {
+            handleTruncate(disTruncate)
+
+            if (!expanded) {
+              onTruncate?.(disTruncate)
+            }
+          }}
         >
           {children}
         </Truncate>


### PR DESCRIPTION
### Description

* The [`<ShowMore />`](https://github.com/remanufacturing/react-truncate/pull/24/files#diff-889cece01891bedc9e25fdaaba56c50382914d1918ead9c8b971f56af65a402c) component had an `onTruncate` prop that wasn't triggered when truncation occurred. This change ensures the callback is properly invoked.

### Changes

* Updated the `onTruncate` prop usage in the [`<ShowMore />`](https://github.com/remanufacturing/react-truncate/pull/24/files#diff-889cece01891bedc9e25fdaaba56c50382914d1918ead9c8b971f56af65a402c) component to call the callback when the content is truncated.

### Testing

* Confirmed that the `onTruncate` prop is now invoked during truncation.