### PR TITLE
chore: add use-client directive to components

### DIFF
--- a/src/MiddleTruncate/MiddleTruncate.tsx
+++ b/src/MiddleTruncate/MiddleTruncate.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 import { Truncate, type TruncateProps } from '@/Truncate'
 import { type MiddleTruncateProps } from './types'

--- a/src/ShowMore/ShowMore.tsx
+++ b/src/ShowMore/ShowMore.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   forwardRef,
   useCallback,

--- a/src/Truncate/Truncate.tsx
+++ b/src/Truncate/Truncate.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { type TruncateProps } from './types'
 import {


### PR DESCRIPTION

Adds the [`use-client`](https://react.dev/reference/rsc/use-client) directive to the library components.

Without the `use-client` directive, attempting to use the library components inside of server components yields TS errors like this one:

```
⨯ [TypeError: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component] {
  digest: '433421930'
```